### PR TITLE
Narrow query for order scheduled_actions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Improved performance and accuracy of scheduled actions query.
+
 ------------------
 ## [1.1.0] - 2025-10-20
 

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -158,7 +158,7 @@ class MetaBox extends OrderMetabox {
 		);
 
 		if ( ! empty( $session_id ) ) {
-			$scheduled_actions = ScheduledActions::get_scheduled_actions( $session_id );
+			$scheduled_actions = ScheduledActions::get_scheduled_actions( $session_id, $order->get_date_created()->date( 'Y-m-d H:i:s' ) );
 			$link_text         = count( $scheduled_actions['complete'] ) . ' completed, ' . count( $scheduled_actions['failed'] ) . ' failed, ' . count( $scheduled_actions['pending'] ) . ' pending';
 			$link_url          = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $session_id ) . '&action=-1&paged=1&action2=-1' );
 

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -158,7 +158,7 @@ class MetaBox extends OrderMetabox {
 		);
 
 		if ( ! empty( $session_id ) ) {
-			$scheduled_actions = ScheduledActions::get_scheduled_actions( $session_id, $order->get_date_created()->date( 'Y-m-d H:i:s' ) );
+			$scheduled_actions = ScheduledActions::get_scheduled_actions( $session_id, gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ) );
 			$link_text         = count( $scheduled_actions['complete'] ) . ' completed, ' . count( $scheduled_actions['failed'] ) . ' failed, ' . count( $scheduled_actions['pending'] ) . ' pending';
 			$link_url          = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $session_id ) . '&action=-1&paged=1&action2=-1' );
 

--- a/src/ScheduledActions.php
+++ b/src/ScheduledActions.php
@@ -16,62 +16,28 @@ class ScheduledActions {
 	 * Gets the scheduled actions for the order.
 	 *
 	 * @param string $session_id The session ID.
+	 * @param string $order_created_date The order creation date in 'Y-m-d H:i:s' format (UTC).
 	 * @return array
 	 */
-	public static function get_scheduled_actions( $session_id ) {
+	public static function get_scheduled_actions( $session_id, $order_created_date ) {
 		$statuses          = array( 'complete', 'failed', 'pending' );
 		$scheduled_actions = array();
 
 		foreach ( $statuses as $status ) {
 			$scheduled_actions[ $status ] = as_get_scheduled_actions(
 				array(
-					'search'   => $session_id,
-					'status'   => array( $status ),
-					'per_page' => -1,
+					'search'       => $session_id,
+					'status'       => array( $status ),
+					'per_page'     => -1,
+					'hook'         => 'kp_wc_authorization',
+					'date'         => $order_created_date,
+					'date_compare' => '>=',
 				),
 				'ids'
 			);
 		}
 
 		return $scheduled_actions;
-	}
-
-	/**
-	 * Prints the scheduled actions for the order.
-	 *
-	 * @param string $session_id The session ID.
-	 * @return void
-	 */
-	public static function print_scheduled_actions( $session_id ) {
-
-		// Allow disabling the display of scheduled actions via a filter.
-		if ( apply_filters( 'kom_skip_scheduled_actions', false ) ) {
-			return;
-		}
-
-		$scheduled_actions = self::get_scheduled_actions( $session_id );
-		$session_query_url = admin_url(
-			'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $session_id ) . '&action=-1&paged=1&action2=-1'
-		);
-		?>
-		<h4>
-			<?php esc_html_e( 'Scheduled actions ', 'klarna-order-management-for-woocommerce' ); ?>
-			<span class="woocommerce-help-tip"
-					data-tip="<?php esc_html_e( 'See all actions scheduled for this order.', 'klarna-order-management-for-woocommerce' ); ?>">
-			</span>
-		</h4>
-		<a target="_blank" href="<?php echo esc_url( $session_query_url ); ?>">
-			<?php
-			printf(
-			// translators: %1$d: number of completed orders, %2$d: number of failed orders, %3$d: number of pending orders.
-				esc_html__( '%1$d completed, %2$d failed, %3$d pending', 'klarna-order-management-for-woocommerce' ),
-				esc_html( count( $scheduled_actions['complete'] ) ),
-				esc_html( count( $scheduled_actions['failed'] ) ),
-				esc_html( count( $scheduled_actions['pending'] ) )
-			);
-			?>
-		</a>
-		<?php
 	}
 }
 new ScheduledActions();

--- a/src/ScheduledActions.php
+++ b/src/ScheduledActions.php
@@ -23,18 +23,24 @@ class ScheduledActions {
 		$statuses          = array( 'complete', 'failed', 'pending' );
 		$scheduled_actions = array();
 
-		foreach ( $statuses as $status ) {
-			$scheduled_actions[ $status ] = as_get_scheduled_actions(
-				array(
-					'search'       => $session_id,
-					'status'       => array( $status ),
-					'per_page'     => -1,
-					'hook'         => 'kp_wc_authorization',
-					'date'         => $order_created_date,
-					'date_compare' => '>=',
-				),
-				'ids'
-			);
+		$order_created_timestamp = strtotime( $order_created_date );
+		$three_months_ago        = strtotime( '-3 months' );
+
+		if ( $order_created_timestamp >= $three_months_ago ) {
+			foreach ( $statuses as $status ) {
+				$scheduled_actions[ $status ] = as_get_scheduled_actions(
+					array(
+						'search'       => $session_id,
+						'status'       => array( $status ),
+						'per_page'     => -1,
+						'hook'         => 'kp_wc_authorization',
+						'group'        => 'klarna_authorization',
+						'date'         => $order_created_date,
+						'date_compare' => '>=',
+					),
+					'ids'
+				);
+			}
 		}
 
 		return $scheduled_actions;


### PR DESCRIPTION
Narrow query for order scheduled_actions. Seems to work well (have tested to mess up/remove all arguments (date etc), which does cause it not to return anything.

I assume this is the only hook to target?