### PR TITLE
Add section for transaction duplicates to metabox

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a "Transaction duplicates" section to the Klarna Order Management admin metabox to show other WooCommerce orders sharing the same Klarna transaction ID, helping merchants identify related or duplicate orders. The filter `kom_skip_matching_reference_orders` allows the disabling of this feature.
+
 * Integrated the support package to enable optional logging, system report entries, and issue reporting.
 
 ------------------

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -172,32 +172,32 @@ class MetaBox extends OrderMetabox {
 		$transaction_id = $order->get_transaction_id();
 
 		if ( ! empty( $transaction_id ) ) {
-			$orders_with_same_transaction_id = Utility::get_orders_by_transaction_id( $transaction_id, $order_id ) ?? array();
+			$matching_reference_orders = Utility::get_matching_reference_orders( $transaction_id, $order_id, $order->get_date_created() ) ?? array();
 
-			if ( ! empty( $orders_with_same_transaction_id ) ) {
-				$same_ref_orders_string = '';
+			if ( ! empty( $matching_reference_orders ) ) {
+				$matching_orders_string = '';
 
-				foreach ( $orders_with_same_transaction_id as $related_order_id ) {
+				foreach ( $matching_reference_orders as $matching_order_id ) {
 
-					$related_order = wc_get_order( $related_order_id );
+					$related_order = wc_get_order( $matching_order_id );
 
 					if ( ! $related_order ) {
 						continue;
 					}
 
-					$same_ref_orders_string .= sprintf(
+					$matching_orders_string .= sprintf(
 						'<li><a target="_blank" href="%s">#%s - %s - %s</a></li>',
-						esc_url( admin_url( 'post.php?post=' . $related_order_id . '&action=edit' ) ),
-						esc_html( $related_order_id ),
+						esc_url( admin_url( 'post.php?post=' . $matching_order_id . '&action=edit' ) ),
+						esc_html( $matching_order_id ),
 						esc_html( $related_order->get_date_created()->date( 'Y-m-d H:i:s' ) ),
 						esc_html( wc_get_order_status_name( $related_order->get_status() ) )
 					);
 
 				}
-				if ( ! empty( $same_ref_orders_string ) ) {
+				if ( ! empty( $matching_orders_string ) ) {
 					self::output_info(
 						__( 'Orders with same reference', 'klarna-order-management' ),
-						'<ul>' . $same_ref_orders_string . '</ul>',
+						'<ul>' . $matching_orders_string . '</ul>',
 						'These orders share the same Klarna transaction ID.'
 					);
 				}

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -178,13 +178,26 @@ class MetaBox extends OrderMetabox {
 		if ( ! empty( $matching_reference_orders ) ) {
 			$matching_orders_string = '';
 
+			$related_orders = array();
+
+			$related_orders = wc_get_orders(
+				array(
+					'type'    => 'shop_order',
+					'include' => $matching_reference_orders,
+					'limit'   => count( $matching_reference_orders ),
+				)
+			);
+
+			$related_orders_by_id = array();
+			foreach ( $related_orders as $related_order ) {
+				$related_orders_by_id[ $related_order->get_id() ] = $related_order;
+			}
+
 			foreach ( $matching_reference_orders as $matching_order_id ) {
-
-				$related_order = wc_get_order( $matching_order_id );
-
-				if ( ! $related_order ) {
+				if ( ! isset( $related_orders_by_id[ $matching_order_id ] ) ) {
 					continue;
 				}
+				$related_order = $related_orders_by_id[ $matching_order_id ];
 
 				$matching_orders_string .= sprintf(
 					'<li><a target="_blank" rel="noopener noreferrer" href="%s">#%s - %s - %s</a></li>',

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -171,38 +171,37 @@ class MetaBox extends OrderMetabox {
 		}
 		$transaction_id = $order->get_transaction_id();
 
-		if ( ! empty( $transaction_id ) ) {
-			$matching_reference_orders = Utility::get_matching_reference_orders( $transaction_id, $order_id, $order->get_date_created() ) ?? array();
+		$matching_reference_orders = Utility::get_matching_reference_orders( $transaction_id, $order_id, $order->get_date_created() ) ?? array();
 
-			if ( ! empty( $matching_reference_orders ) ) {
-				$matching_orders_string = '';
+		if ( ! empty( $matching_reference_orders ) ) {
+			$matching_orders_string = '';
 
-				foreach ( $matching_reference_orders as $matching_order_id ) {
+			foreach ( $matching_reference_orders as $matching_order_id ) {
 
-					$related_order = wc_get_order( $matching_order_id );
+				$related_order = wc_get_order( $matching_order_id );
 
-					if ( ! $related_order ) {
-						continue;
-					}
-
-					$matching_orders_string .= sprintf(
-						'<li><a target="_blank" href="%s">#%s - %s - %s</a></li>',
-						esc_url( admin_url( 'post.php?post=' . $matching_order_id . '&action=edit' ) ),
-						esc_html( $matching_order_id ),
-						esc_html( $related_order->get_date_created()->date( 'Y-m-d H:i:s' ) ),
-						esc_html( wc_get_order_status_name( $related_order->get_status() ) )
-					);
-
+				if ( ! $related_order ) {
+					continue;
 				}
-				if ( ! empty( $matching_orders_string ) ) {
-					self::output_info(
-						__( 'Orders with same reference', 'klarna-order-management' ),
-						'<ul>' . $matching_orders_string . '</ul>',
-						'These orders share the same Klarna transaction ID.'
-					);
-				}
+
+				$matching_orders_string .= sprintf(
+					'<li><a target="_blank" href="%s">#%s - %s - %s</a></li>',
+					esc_url( admin_url( 'post.php?post=' . $matching_order_id . '&action=edit' ) ),
+					esc_html( $matching_order_id ),
+					esc_html( $related_order->get_date_created()->date( 'Y-m-d H:i:s' ) ),
+					esc_html( wc_get_order_status_name( $related_order->get_status() ) )
+				);
+
+			}
+			if ( ! empty( $matching_orders_string ) ) {
+				self::output_info(
+					__( 'Orders with same reference', 'klarna-order-management' ),
+					'<ul>' . $matching_orders_string . '</ul>',
+					'These orders share the same Klarna transaction ID.'
+				);
 			}
 		}
+
 		( new OrderSupport() )->add_export_order_button( $order, true );
 		self::output_actions_dropdown( $order_id, $klarna_order );
 		self::output_collapsable_section( 'kom-advanced', __( 'Advanced', 'klarna-order-management' ), self::get_advanced_section_content( $order ) );

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -171,7 +171,9 @@ class MetaBox extends OrderMetabox {
 		}
 		$transaction_id = $order->get_transaction_id();
 
-		$matching_reference_orders = Utility::get_matching_reference_orders( $transaction_id, $order_id, $order->get_date_created() ) ?? array();
+		$order_date_created        = $order->get_date_created();
+		$order_date_created_str    = $order_date_created ? $order_date_created->date( 'c' ) : null;
+		$matching_reference_orders = Utility::get_matching_reference_orders( $transaction_id, $order_id, $order_date_created_str ) ?? array();
 
 		if ( ! empty( $matching_reference_orders ) ) {
 			$matching_orders_string = '';
@@ -185,7 +187,7 @@ class MetaBox extends OrderMetabox {
 				}
 
 				$matching_orders_string .= sprintf(
-					'<li><a target="_blank" href="%s">#%s - %s - %s</a></li>',
+					'<li><a target="_blank" rel="noopener noreferrer" href="%s">#%s - %s - %s</a></li>',
 					esc_url( admin_url( 'post.php?post=' . $matching_order_id . '&action=edit' ) ),
 					esc_html( $matching_order_id ),
 					esc_html( $related_order->get_date_created()->date( 'Y-m-d H:i:s' ) ),
@@ -197,7 +199,7 @@ class MetaBox extends OrderMetabox {
 				self::output_info(
 					__( 'Orders with same reference', 'klarna-order-management' ),
 					'<ul>' . $matching_orders_string . '</ul>',
-					'These orders share the same Klarna transaction ID.'
+					__( 'These orders share the same Klarna transaction ID.', 'klarna-order-management' )
 				);
 			}
 		}

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -178,33 +178,14 @@ class MetaBox extends OrderMetabox {
 		if ( ! empty( $matching_reference_orders ) ) {
 			$matching_orders_string = '';
 
-			$related_orders = array();
-
-			$related_orders = wc_get_orders(
-				array(
-					'type'    => 'shop_order',
-					'include' => $matching_reference_orders,
-					'limit'   => count( $matching_reference_orders ),
-				)
-			);
-
-			$related_orders_by_id = array();
-			foreach ( $related_orders as $related_order ) {
-				$related_orders_by_id[ $related_order->get_id() ] = $related_order;
-			}
-
-			foreach ( $matching_reference_orders as $matching_order_id ) {
-				if ( ! isset( $related_orders_by_id[ $matching_order_id ] ) ) {
-					continue;
-				}
-				$related_order = $related_orders_by_id[ $matching_order_id ];
+			foreach ( $matching_reference_orders as $matching_order ) {
 
 				$matching_orders_string .= sprintf(
 					'<li><a target="_blank" rel="noopener noreferrer" href="%s">#%s - %s - %s</a></li>',
-					esc_url( admin_url( 'post.php?post=' . $matching_order_id . '&action=edit' ) ),
-					esc_html( $matching_order_id ),
-					esc_html( $related_order->get_date_created()->date( 'Y-m-d H:i:s' ) ),
-					esc_html( wc_get_order_status_name( $related_order->get_status() ) )
+					esc_url( admin_url( 'post.php?post=' . $matching_order->get_id() . '&action=edit' ) ),
+					esc_html( $matching_order->get_id() ),
+					esc_html( $matching_order->get_date_created()->date( 'Y-m-d H:i:s' ) ),
+					esc_html( wc_get_order_status_name( $matching_order->get_status() ) )
 				);
 
 			}

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -169,6 +169,40 @@ class MetaBox extends OrderMetabox {
 			);
 
 		}
+		$transaction_id = $order->get_transaction_id();
+
+		if ( ! empty( $transaction_id ) ) {
+			$orders_with_same_transaction_id = Utility::get_orders_by_transaction_id( $transaction_id, $order_id ) ?? array();
+
+			if ( ! empty( $orders_with_same_transaction_id ) ) {
+				$same_ref_orders_string = '';
+
+				foreach ( $orders_with_same_transaction_id as $related_order_id ) {
+
+					$related_order = wc_get_order( $related_order_id );
+
+					if ( ! $related_order ) {
+						continue;
+					}
+
+					$same_ref_orders_string .= sprintf(
+						'<li><a target="_blank" href="%s">#%s - %s - %s</a></li>',
+						esc_url( admin_url( 'post.php?post=' . $related_order_id . '&action=edit' ) ),
+						esc_html( $related_order_id ),
+						esc_html( $related_order->get_date_created()->date( 'Y-m-d H:i:s' ) ),
+						esc_html( wc_get_order_status_name( $related_order->get_status() ) )
+					);
+
+				}
+				if ( ! empty( $same_ref_orders_string ) ) {
+					self::output_info(
+						__( 'Orders with same reference', 'klarna-order-management' ),
+						'<ul>' . $same_ref_orders_string . '</ul>',
+						'These orders share the same Klarna transaction ID.'
+					);
+				}
+			}
+		}
 		( new OrderSupport() )->add_export_order_button( $order, true );
 		self::output_actions_dropdown( $order_id, $klarna_order );
 		self::output_collapsable_section( 'kom-advanced', __( 'Advanced', 'klarna-order-management' ), self::get_advanced_section_content( $order ) );

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -85,7 +85,7 @@ class Utility {
 	 * @param int    $current_order_id The current order ID to exclude.
 	 * @param string $order_date The order date.
 	 *
-	 * @return array An array of matching order IDs.
+	 * @return array An array of matching orders.
 	 */
 	public static function get_matching_reference_orders( $transaction_id, $current_order_id, $order_date ) {
 
@@ -100,11 +100,17 @@ class Utility {
 		$args   = array(
 			'limit'          => 10,
 			'transaction_id' => $transaction_id,
-			'return'         => 'ids',
 			'exclude'        => array( $current_order_id ),
 			'date_created'   => $start_date . '...' . $end_date,
 		);
 		$orders = wc_get_orders( $args );
+
+		$orders = array_filter(
+			$orders,
+			function ( $order ) use ( $transaction_id ) {
+				return $order->get_transaction_id() === $transaction_id;
+			}
+		);
 
 		return $orders;
 	}

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -87,6 +87,11 @@ class Utility {
 	 * @param string $order_date The order date.
 	 */
 	public static function get_matching_reference_orders( $transaction_id, $current_order_id, $order_date ) {
+
+		if ( empty( $transaction_id ) ) {
+			return array();
+		}
+
 		$order_date = new \DateTime( $order_date );
 		$start_date = $order_date->modify( '-7 days' )->format( 'Y-m-d' );
 		$end_date   = $order_date->modify( '+7 days' )->format( 'Y-m-d' );

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -77,4 +77,24 @@ class Utility {
 		}
 		return false;
 	}
+
+	/**
+	 * Get orders by transaction id, excluding the current order ID.
+	 *
+	 * @param string $transaction_id The transaction ID.
+	 * @param int    $current_order_id The current order ID to exclude.
+	 * @return array The order IDs.
+	 */
+	public static function get_orders_by_transaction_id( $transaction_id, $current_order_id ) {
+
+		$args   = array(
+			'limit'          => -1,
+			'transaction_id' => $transaction_id,
+			'return'         => 'ids',
+			'exclude'        => array( $current_order_id ),
+		);
+		$orders = wc_get_orders( $args );
+
+		return $orders;
+	}
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -89,6 +89,11 @@ class Utility {
 	 */
 	public static function get_matching_reference_orders( $transaction_id, $current_order_id, $order_date ) {
 
+		// Allow disabling the display of matching reference orders via a filter.
+		if ( apply_filters( 'kom_skip_matching_reference_orders', false ) ) {
+			return;
+		}
+
 		if ( empty( $transaction_id ) ) {
 			return array();
 		}

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -83,8 +83,9 @@ class Utility {
 	 *
 	 * @param string $transaction_id The transaction ID.
 	 * @param int    $current_order_id The current order ID to exclude.
-	 * @return array The order IDs.
 	 * @param string $order_date The order date.
+	 *
+	 * @return array An array of matching order IDs.
 	 */
 	public static function get_matching_reference_orders( $transaction_id, $current_order_id, $order_date ) {
 
@@ -93,11 +94,11 @@ class Utility {
 		}
 
 		$order_date = new \DateTime( $order_date );
-		$start_date = $order_date->modify( '-7 days' )->format( 'Y-m-d' );
-		$end_date   = $order_date->modify( '+7 days' )->format( 'Y-m-d' );
+		$start_date = ( clone $order_date )->modify( '-7 days' )->format( 'Y-m-d' );
+		$end_date   = ( clone $order_date )->modify( '+7 days' )->format( 'Y-m-d' );
 
 		$args   = array(
-			'limit'          => -1,
+			'limit'          => 10,
 			'transaction_id' => $transaction_id,
 			'return'         => 'ids',
 			'exclude'        => array( $current_order_id ),

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -79,19 +79,24 @@ class Utility {
 	}
 
 	/**
-	 * Get orders by transaction id, excluding the current order ID.
+	 * Get orders with matching transaction ID within a date range.
 	 *
 	 * @param string $transaction_id The transaction ID.
 	 * @param int    $current_order_id The current order ID to exclude.
 	 * @return array The order IDs.
+	 * @param string $order_date The order date.
 	 */
-	public static function get_orders_by_transaction_id( $transaction_id, $current_order_id ) {
+	public static function get_matching_reference_orders( $transaction_id, $current_order_id, $order_date ) {
+		$order_date = new \DateTime( $order_date );
+		$start_date = $order_date->modify( '-7 days' )->format( 'Y-m-d' );
+		$end_date   = $order_date->modify( '+7 days' )->format( 'Y-m-d' );
 
 		$args   = array(
 			'limit'          => -1,
 			'transaction_id' => $transaction_id,
 			'return'         => 'ids',
 			'exclude'        => array( $current_order_id ),
+			'date_created'   => $start_date . '...' . $end_date,
 		);
 		$orders = wc_get_orders( $args );
 


### PR DESCRIPTION
Add section to the Klarna order management metabox, to list orders that share the same Klarna transaction ID.

**Question:** Could the query be narrowed here? I'm unsure about limiting dates, but perhaps that could be done without risking missed orders?